### PR TITLE
feat: Update docstrings in various files

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -4,14 +4,18 @@
     "specifiers": {
       "jsr:@deno/cache-dir@^0.8.0": "jsr:@deno/cache-dir@0.8.0",
       "jsr:@deno/dnt@^0.41.1": "jsr:@deno/dnt@0.41.1",
+      "jsr:@std/assert@0.222.1": "jsr:@std/assert@0.222.1",
       "jsr:@std/assert@^0.218.2": "jsr:@std/assert@0.218.2",
       "jsr:@std/bytes@^0.218.2": "jsr:@std/bytes@0.218.2",
       "jsr:@std/fmt@^0.218.2": "jsr:@std/fmt@0.218.2",
+      "jsr:@std/fmt@^0.222.1": "jsr:@std/fmt@0.222.1",
       "jsr:@std/fs@^0.218.2": "jsr:@std/fs@0.218.2",
       "jsr:@std/io@^0.218.2": "jsr:@std/io@0.218.2",
       "jsr:@std/path@^0.218.2": "jsr:@std/path@0.218.2",
+      "jsr:@std/testing@0.222.1": "jsr:@std/testing@0.222.1",
       "npm:@ts-morph/bootstrap@0.22": "npm:@ts-morph/bootstrap@0.22.0",
-      "npm:code-block-writer@^13.0.1": "npm:code-block-writer@13.0.1"
+      "npm:code-block-writer@^13.0.1": "npm:code-block-writer@13.0.1",
+      "npm:type-fest@4.15.0": "npm:type-fest@4.15.0"
     },
     "jsr": {
       "@deno/cache-dir@0.8.0": {
@@ -35,11 +39,20 @@
       "@std/assert@0.218.2": {
         "integrity": "7f0a5a1a8cf86607cd6c2c030584096e1ffad27fc9271429a8cb48cfbdee5eaf"
       },
+      "@std/assert@0.222.1": {
+        "integrity": "691637161ee584a9919d1f9950ddd1272feb8e0a19e83aa5b7563cedaf73d74c",
+        "dependencies": [
+          "jsr:@std/fmt@^0.222.1"
+        ]
+      },
       "@std/bytes@0.218.2": {
         "integrity": "91fe54b232dcca73856b79a817247f4a651dbb60d51baafafb6408c137241670"
       },
       "@std/fmt@0.218.2": {
         "integrity": "99526449d2505aa758b6cbef81e7dd471d8b28ec0dcb1491d122b284c548788a"
+      },
+      "@std/fmt@0.222.1": {
+        "integrity": "ec3382f9b0261c1ab1a5c804aa355d816515fa984cdd827ed32edfb187c0a722"
       },
       "@std/fs@0.218.2": {
         "integrity": "dd9431453f7282e8c577cc22c9e6d036055a9a980b5549f887d6012969fabcca",
@@ -59,6 +72,9 @@
         "dependencies": [
           "jsr:@std/assert@^0.218.2"
         ]
+      },
+      "@std/testing@0.222.1": {
+        "integrity": "7be5c3ef185d31883116824a2dd604eb6f12a56fd5ed80489c7c696b2a76c5bc"
       }
     },
     "npm": {
@@ -205,6 +221,10 @@
         "dependencies": {
           "is-number": "is-number@7.0.0"
         }
+      },
+      "type-fest@4.15.0": {
+        "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+        "dependencies": {}
       }
     }
   },

--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
+    "@ryoppippi/str-fns": "./src/index.ts",
     "type-fest": "npm:type-fest@4.15.0",
     "assert": "jsr:@std/assert@0.222.1",
     "type-testing": "jsr:@std/testing@0.222.1/types",

--- a/src/capitalize.ts
+++ b/src/capitalize.ts
@@ -4,18 +4,16 @@ type CapitalizedString<T extends Readonly<string>> = IsStringLiteral<T> extends
   true ? Capitalize<T> : string;
 
 /**
- * @description capitalize first letter of string
+ * capitalize first letter of string
+ *
+ * ```ts
+ * import { capitalize } from '@ryoppippi/str-fns'
+ * const _: 'A' = capitalize('a');
+ * const __: 'Abc' = capitalize('abc');
+ * const ___: '' = capitalize('');
+ * ```
  *
  * @param input - input string to capitalize. type should be matched to T
- *
- * @example
- * capitalize('a') // returns 'A'
- *
- * @example
- * capitalize('abc') // returns 'Abc'
- *
- * @example
- * capitalize('') // returns ''
  */
 export function capitalize<T extends Readonly<string>>(
   input: T,

--- a/src/lowercase.ts
+++ b/src/lowercase.ts
@@ -4,18 +4,15 @@ type LowercaseString<T extends Readonly<string>> = IsStringLiteral<T> extends
   true ? Lowercase<T> : string;
 
 /**
- * @description get lowercase string
+ * get lowercase string
  *
+ * ```ts
+ * import { lowercase } from '@ryoppippi/str-fns'
+ * const _: 'a' = lowercase('A');
+ * const __: 'abc' = lowercase('aBC');
+ * const ___: '' = lowercase('');
+ * ```
  * @param input - input string to capitalize. type should be matched to T
- *
- * @example
- * lowercase('A') // 'a'
- *
- * @example
- * lowercase('aBC') // 'abc'
- *
- * @example
- * lowercase('') // ''
  */
 export function lowercase<T extends Readonly<string>>(
   input: T,

--- a/src/split.ts
+++ b/src/split.ts
@@ -7,23 +7,19 @@ type SplitString<
   : Readonly<string[]>;
 
 /**
- * @description Split string by separator
+ *  Split string by separator
+ *
+ * ```ts
+ * import { split } from '@ryoppippi/str-fns'
+ * const _: readonly ['A', 'c'] = split('Abc', 'b');
+ * const __: readonly ['a', 'b', 'c'] = split('a-b-c', '-');
+ * const ___: readonly ['a', '-', 'b', '-', 'c'] = split('a-b-c', '');
+ * const ____: readonly ['a-b-c'] = split('a-b-c', '$');
+ * ```
  *
  * @param input - string to split. type should be matched to T
  *
  * @param separator - separator to split string. type should be matched to U
- *
- * @example
- * split('Abc', 'b') // returns ['A', 'c']
- *
- * @example
- * split('a-b-c', '-') // returns ['a', 'b', 'c']
- *
- * @example
- * split('a-b-c', '') // returns ['a', '-', 'b', '-', 'c']
- *
- * @example
- * split('a-b-c', '$') // returns ['a-b-c']
  */
 export function split<T extends Readonly<string>, U extends Readonly<string>>(
   input: T,

--- a/src/uncapitalize.ts
+++ b/src/uncapitalize.ts
@@ -4,18 +4,16 @@ type UncapitalizedString<T extends Readonly<string>> =
   IsStringLiteral<T> extends true ? Uncapitalize<T> : string;
 
 /**
- * @description uncapitalize first letter of string
+ *  uncapitalize first letter of string
+ *
+ * ```ts
+ * import { uncapitalize } from '@ryoppippi/str-fns'
+ * const _: 'a' = uncapitalize('A');
+ * const __: 'abc' = uncapitalize('Abc');
+ * const ___: '' = uncapitalize('');
+ * ```
  *
  * @param input - input string to capitalize. type should be matched to T
- *
- * @example
- * uncapitalize('A') // returns 'a'
- *
- * @example
- * uncapitalize('Abc') // returns 'abc'
- *
- * @example
- * uncapitalize('') // returns ''
  */
 export function uncapitalize<T extends Readonly<string>>(
   input: T,

--- a/src/uppercase.ts
+++ b/src/uppercase.ts
@@ -6,16 +6,14 @@ type UppercaseString<T extends Readonly<string>> = IsStringLiteral<T> extends
 /**
  * @description get uppercase string
  *
+ * ```ts
+ * import { uppercase } from '@ryoppippi/str-fns'
+ * const _: 'A' = uppercase('a');
+ * const __: 'ABC' = uppercase('abc');
+ * const ___: '' = uppercase('');
+ * ```
+ *
  * @param input - input string to capitalize. type should be matched to T
- *
- * @example
- * uppercase('a') // 'A'
- *
- * @example
- * uppercase('abc') // 'Abc'
- *
- * @example
- * uppercase('') // ''
  */
 export function uppercase<T extends Readonly<string>>(
   input: T,


### PR DESCRIPTION
This commit updates the docstrings in the following files:
capitalize.ts, lowercase.ts, split.ts, uncapitalize.ts, and
uppercase.ts. The changes include the removal of redundant
examples and the addition of more concise and illustrative
examples. This makes the documentation more readable and
understandable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for text transformation functions including `capitalize`, `lowercase`, `uncapitalize`, and `uppercase` to provide clearer and more concise usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->