### PR TITLE
feat: upgrade type-fest to version 4.18.1

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -15,7 +15,9 @@
       "jsr:@std/testing@0.222.1": "jsr:@std/testing@0.222.1",
       "npm:@ts-morph/bootstrap@0.22": "npm:@ts-morph/bootstrap@0.22.0",
       "npm:code-block-writer@^13.0.1": "npm:code-block-writer@13.0.1",
-      "npm:type-fest@4.15.0": "npm:type-fest@4.15.0"
+      "npm:type-fest@4.15.0": "npm:type-fest@4.15.0",
+      "npm:type-fest@4.18.0": "npm:type-fest@4.18.0",
+      "npm:type-fest@4.18.1": "npm:type-fest@4.18.1"
     },
     "jsr": {
       "@deno/cache-dir@0.8.0": {
@@ -224,6 +226,14 @@
       },
       "type-fest@4.15.0": {
         "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+        "dependencies": {}
+      },
+      "type-fest@4.18.0": {
+        "integrity": "sha512-+dbmiyliDY/2TTcjCS7NpI9yV2iEFlUDk5TKnsbkN7ZoRu5s7bT+zvYtNFhFXC2oLwURGT2frACAZvbbyNBI+w==",
+        "dependencies": {}
+      },
+      "type-fest@4.18.1": {
+        "integrity": "sha512-qXhgeNsX15bM63h5aapNFcQid9jRF/l3ojDoDFmekDQEUufZ9U4ErVt6SjDxnHp48Ltrw616R8yNc3giJ3KvVQ==",
         "dependencies": {}
       }
     }

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@ryoppippi/str-fns": "./src/index.ts",
-    "type-fest": "npm:type-fest@4.15.0",
+    "type-fest": "npm:type-fest@4.18.1",
     "assert": "jsr:@std/assert@0.222.1",
     "type-testing": "jsr:@std/testing@0.222.1/types",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.1"


### PR DESCRIPTION
This commit updates the version of type-fest from 4.15.0 to 4.18.1 in
the import_map.json file. The deno.lock file has also been updated to
reflect this change.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
