### PR TITLE
feat(ci.yaml): Add pkg.pr.now upload to npm-publish job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           deno-version: ${{ env.DENO_VERSION }}
       - run: deno publish --dry-run
 
-  npm-publish-dry-run:
+  npm-publish-dry-run-and-upload-pkg-pr-now:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,14 +62,18 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
       - run: deno task build-npm
-      - run: |
-          cd npm
-          npm publish --dry-run
+      - name: npm publish dry-run
+        run: npm publish --dry-run
+        working-directory: npm/
+      - name: upload to pkg.pr.now
+        run: bunx pkg-pr-new publish
+        working-directory: npm/
 
   action-timeline:
     needs: 
       - check-test
       - jsr-publish-dry-run
+      - npm-publish-dry-run-and-upload-pkg-pr-now
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit modifies the npm-publish-dry-run job in the GitHub Actions workflow. It now includes a step to upload the built npm package to pkg.pr.now for previewing. The job name has been updated to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow for npm publish to include a new step for package upload and renamed the job for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->