### PR TITLE
feat(deno.jsonc): remove build-npm script

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -20,8 +20,7 @@
     "test": "deno test -A --parallel --doc",
     "test:coverage": "deno task test --coverage=coverage",
     "coverage:show": "deno coverage ./coverage",
-    "coverage:lco": "deno coverage --lcov ./coverage > ./coverage/lcov.info",
-    "build-npm": "deno run -A scripts/build_npm.ts $(git describe --tags --always --dirty)"
+    "coverage:lco": "deno coverage --lcov ./coverage > ./coverage/lcov.info"
   },
   "fmt": {
     "exclude": [


### PR DESCRIPTION
The build-npm script was removed from the deno.jsonc file. This change
simplifies the script section and removes an unused build command.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
